### PR TITLE
Add parse_entity_lookup plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM composer:1.10.17
 RUN apk add --no-cache \
       php7-gd \
       zlib-dev \
-      libpng-dev
+      libpng-dev \
+      autoconf \
+      gcc \
+      musl-dev
 
 RUN docker-php-ext-install gd
+
+RUN (echo '' | pecl install xdebug)

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,60 @@
-
-DOCKER_REGISTRY=local
-CONTAINER_NAME=testing
+DOCKER_REGISTRY=ghcr.io/jhu-sheridan-libraries/idc-isle-dc
+CONTAINER_NAME=idc_migration-testing
+GIT_TAG:=$(shell git describe --tags --always)
 
 .PHONY: help
 help:
 	@echo "IDC Migration PHP module supported make targets are:"
-	@echo "  build-container: builds the Docker image used for tests"
+	@echo "  build-image: builds the Docker image used for tests"
+	@echo "  push-image: pushes the Docker image to GHCR"
 	@echo "  composer-install: installs the dependencies in composer.lock"
+	@echo "  composer-update: updates the dependencies in composer.lock per composer.json version requirements"
 	@echo "  check-platform-reqs: insures the PHP version and installed extensions are runtime compatible"
 	@echo "  test: executes unit tests"
-	@echo "  clean: removes build state from '.make/' and removes the Docker image used for tests"
+	@echo "  clean: removes build state from '.make/', the Docker image used for tests, the 'vendor' directory, and composer.lock"
 
-.PHONY: build-container
-build-container: .make/build-container
+.PHONY: build-image
+build-image: .make/build-image
 
-.make/build-container:
-	docker build -t ${DOCKER_REGISTRY}/${CONTAINER_NAME} .
-	@touch .make/build-container
+.make/build-image:
+	docker build -t ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG} .
+	@touch .make/build-image
+
+.PHONY: push-image
+push-image: .make/push-image
+
+.make/push-image: .make/build-image
+	docker push ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG}
+	@touch .make/push-image
+
+.PHONY: composer-update
+composer-update: .make/build-image .make/composer-update
+
+.make/composer-update:
+	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG} update
+	@touch .make/composer-update
 
 .PHONY: composer-install
-composer-install: .make/build-container .make/composer-install
+composer-update: .make/build-image .make/composer-install
 
 .make/composer-install:
-	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME} install
+	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG} install
 	@touch .make/composer-install
 
 .PHONY: check-platform-reqs
-check-platform-reqs: .make/build-container .make/composer-install .make/check-platform-reqs
+check-platform-reqs: .make/build-image .make/composer-update .make/check-platform-reqs
 
 .make/check-platform-reqs:
-	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME} check-platform-reqs
+	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG} check-platform-reqs
 	@touch .make/check-platform-reqs
 
 .PHONY: test
-test: .make/build-container .make/composer-install .make/check-platform-reqs
-	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME} vendor/bin/phpunit tests
+test: .make/build-image .make/composer-install .make/check-platform-reqs
+	docker run --rm -v $$PWD:/app ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG} vendor/bin/phpunit tests
 
 .PHONY: clean
 clean:
-	-docker rmi ${DOCKER_REGISTRY}/${CONTAINER_NAME}
+	-docker rmi ${DOCKER_REGISTRY}/${CONTAINER_NAME}:${GIT_TAG}
 	-rm -f .make/*
+	-rm -rf vendor/
+	-rm -f composer.lock

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # IDC Migration Module
-A [composer][1]-based project providing custom migration plugins for Drupal. 
+A [composer][1]-based project providing custom migration plugins for Drupal.
 
-The supplied Dockerfile may be used to run tests and execute `composer` commands.  The `Makefile` provides common targets used to setup the development environment and execute tests.
+Provided plugins include:
+* `deepen`: transforms arrays suitable for input to the `sub_process` migrate module
+* `pairtree`: calculates a checksum for a bytestream, and returns it in a structured form useful for content-based addressing
+* `parse_entity_lookup`: parameterizes instances of the `entity_lookup` plugin by parsing values from the source
 
-Runtime dependencies are maintained in `composer.json`, and should track the versions of dependencies used by the [IDC `drupal` container][2].  For example, if the version of Drupal or PHP is bumped in the `drupal` container, it should be updated in this project as well.  Since migrations are a part of Drupal core, there are no other dependencies on additional migration modules like Migrate Plus.
+The `Makefile` provides common targets used to setup the development environment and execute tests.  Docker provides `composer`, PHPUnit, and any other novel dependencies.
 
 ## Usage
+Runtime dependencies are maintained in `composer.json`, and should track the versions of dependencies used by the [IDC `drupal` container][2].  For example, if the version of Drupal or PHP is bumped in the `drupal` container, it should be updated in this project as well.
+
+### As a dependency
 To depend on this module, add the following to `composer.json`:
 ```json
 "repositories": [
@@ -15,22 +21,24 @@ To depend on this module, add the following to `composer.json`:
     }
 ]
 ```
+And then execute `composer require jhu_idc/idc_migration ^1.0`
 
-And then execute ``composer require jhu_idc/idc_migration ^1.0``
-
-To develop against this module, check out this repository and run `make composer-install`.  Dependencies will be downloaded and installed underneath the `vendor/` subdirectory per the `composer.lock` file.  Once dependencies are installed, IDEs should be able to provide support for development tasks.  
+### For development
+To develop with this module, check out this repository and run `make composer-install`.  Dependencies will be downloaded and installed underneath the `vendor/` subdirectory per the `composer.lock` file.  Once dependencies are installed, IDEs should be able to provide support for development tasks.  
 
 `make help` will provide a list of supported targets and their description.
 
 ## Running tests
 Tests are executed by bind mounting this code inside a Docker container and executing `phpunit` within the container.  This absolves the host of any obligation to install PHP, composer, or PHPUnit.
 
-To run tests: ``make test``
+To run tests: `make test`
+
+If you receive an inexplicable "class not found" error when running a test, you may need to regenerate the autoload information that is produced by composer.  To do that, run a `make clean test`; that will create a new image and run `composer install` which will insure the autoload information is up-to-date.
 
 ## Requires
 - Docker
 - PHP 7.3
-- Drupal 8.8+
+- Drupal 8.9+
 
 
 [1]: https://getcomposer.org/

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,11 @@
   ],
   "require": {
     "php": ">=7.3",
-    "drupal/core": "^8.8.1"
+    "drupal/core": "8.9.13"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5"
+    "phpunit/phpunit": "^7.5",
+    "drupal/migrate_plus": "^5"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5d0ed720fe0a7748aed89f321d100e5",
+    "content-hash": "9300f8e8dfb72816d9a2ffa5d0072bd5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -135,16 +135,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.11.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
+                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
-                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/b17c5014ef81d212ac539f07a1001832df1b6d3b",
+                "reference": "b17c5014ef81d212ac539f07a1001832df1b6d3b",
                 "shasum": ""
             },
             "require": {
@@ -159,11 +159,6 @@
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
@@ -202,7 +197,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2020-10-26T10:28:16+00:00"
+            "time": "2021-02-21T21:00:45+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -554,26 +549,26 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "1.4.3",
+            "version": "1.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "4650c8b30c753a76bf44fb2ed00117d6f367490c"
+                "reference": "4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4650c8b30c753a76bf44fb2ed00117d6f367490c",
-                "reference": "4650c8b30c753a76bf44fb2ed00117d6f367490c",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9",
+                "reference": "4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^7.0",
-                "phpstan/phpstan": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "doctrine/coding-standard": "^8.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
@@ -642,7 +637,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T07:19:59+00:00"
+            "time": "2021-04-16T17:34:40+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -899,16 +894,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.9.11",
+            "version": "8.9.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "8fc1d510b8fcff90e2f3a7c96a893ba16bbdc62d"
+                "reference": "a53db77b55a035453d7229e0c3069f8591cb4cb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/8fc1d510b8fcff90e2f3a7c96a893ba16bbdc62d",
-                "reference": "8fc1d510b8fcff90e2f3a7c96a893ba16bbdc62d",
+                "url": "https://api.github.com/repos/drupal/core/zipball/a53db77b55a035453d7229e0c3069f8591cb4cb6",
+                "reference": "a53db77b55a035453d7229e0c3069f8591cb4cb6",
                 "shasum": ""
             },
             "require": {
@@ -935,7 +930,7 @@
                 "laminas/laminas-diactoros": "^1.8",
                 "laminas/laminas-feed": "^2.12",
                 "masterminds/html5": "^2.1",
-                "pear/archive_tar": "^1.4.11",
+                "pear/archive_tar": "^1.4.12",
                 "php": "^7.0.8",
                 "psr/log": "^1.0",
                 "stack/builder": "^1.0",
@@ -1126,7 +1121,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2020-12-03T20:57:10+00:00"
+            "time": "2021-01-19T23:11:00+00:00"
         },
         {
             "name": "easyrdf/easyrdf",
@@ -1192,16 +1187,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.24",
+            "version": "2.1.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "ca90a3291eee1538cd48ff25163240695bd95448"
+                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/ca90a3291eee1538cd48ff25163240695bd95448",
-                "reference": "ca90a3291eee1538cd48ff25163240695bd95448",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/0dbf5d78455d4d6a41d186da50adc1122ec066f4",
+                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4",
                 "shasum": ""
             },
             "require": {
@@ -1252,7 +1247,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-14T15:56:27+00:00"
+            "time": "2020-12-29T14:50:06+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1323,16 +1318,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
                 "shasum": ""
             },
             "require": {
@@ -1370,20 +1365,20 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2020-09-30T07:37:28+00:00"
+            "time": "2021-03-07T09:25:29+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3"
+                "reference": "35ea11d335fd638b5882ff1725228b3d35496ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/53330f47520498c0ae1f61f7e2c90f55690c06a3",
-                "reference": "53330f47520498c0ae1f61f7e2c90f55690c06a3",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/35ea11d335fd638b5882ff1725228b3d35496ab1",
+                "reference": "35ea11d335fd638b5882ff1725228b3d35496ab1",
                 "shasum": ""
             },
             "require": {
@@ -1441,7 +1436,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2020-09-30T07:37:11+00:00"
+            "time": "2021-03-21T16:25:00+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1575,16 +1570,16 @@
         },
         {
             "name": "laminas/laminas-feed",
-            "version": "2.13.0",
+            "version": "2.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-feed.git",
-                "reference": "fb89aac1984222227f37792dd193d34829a0762f"
+                "reference": "463fdae515fba30633906098c258d3b2c733c15c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/fb89aac1984222227f37792dd193d34829a0762f",
-                "reference": "fb89aac1984222227f37792dd193d34829a0762f",
+                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/463fdae515fba30633906098c258d3b2c733c15c",
+                "reference": "463fdae515fba30633906098c258d3b2c733c15c",
                 "shasum": ""
             },
             "require": {
@@ -1643,7 +1638,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-11-18T21:02:52+00:00"
+            "time": "2021-04-01T19:26:09+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -1697,24 +1692,26 @@
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642"
+                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6ede70583e101030bcace4dcddd648f760ddf642",
-                "reference": "6ede70583e101030bcace4dcddd648f760ddf642",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6cccbddfcfc742eb02158d6137ca5687d92cee32",
+                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
-                "squizlabs/php_codesniffer": "^3.5"
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
             },
             "type": "library",
             "extra": {
@@ -1747,7 +1744,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-09-14T14:23:00+00:00"
+            "time": "2021-02-25T21:54:58+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -1816,16 +1813,16 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.11",
+            "version": "1.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "17d355cb7d3c4ff08e5729f29cd7660145208d9d"
+                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/17d355cb7d3c4ff08e5729f29cd7660145208d9d",
-                "reference": "17d355cb7d3c4ff08e5729f29cd7660145208d9d",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/2b87b41178cc6d4ad3cba678a46a1cae49786011",
+                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011",
                 "shasum": ""
             },
             "require": {
@@ -1878,7 +1875,17 @@
                 "archive",
                 "tar"
             ],
-            "time": "2020-11-19T22:10:24+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/mrook",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/michielrook",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-02-16T10:50:50+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -1973,23 +1980,23 @@
         },
         {
             "name": "pear/pear_exception",
-            "version": "v1.0.1",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/PEAR_Exception.git",
-                "reference": "dbb42a5a0e45f3adcf99babfb2a1ba77b8ac36a7"
+                "reference": "b14fbe2ddb0b9f94f5b24cf08783d599f776fff0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/dbb42a5a0e45f3adcf99babfb2a1ba77b8ac36a7",
-                "reference": "dbb42a5a0e45f3adcf99babfb2a1ba77b8ac36a7",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/b14fbe2ddb0b9f94f5b24cf08783d599f776fff0",
+                "reference": "b14fbe2ddb0b9f94f5b24cf08783d599f776fff0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=4.4.0"
+                "php": ">=5.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "*"
+                "phpunit/phpunit": "<9"
             },
             "type": "class",
             "extra": {
@@ -2024,31 +2031,26 @@
             "keywords": [
                 "exception"
             ],
-            "time": "2019-12-10T10:24:42+00:00"
+            "time": "2021-03-21T15:43:46+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -2061,7 +2063,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -2073,7 +2075,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2469,16 +2471,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.17",
+            "version": "v4.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "65fe7b49868378319b82da3035fb30801b931c47"
+                "reference": "157bbec4fd773bae53c5483c50951a5530a2cc16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/65fe7b49868378319b82da3035fb30801b931c47",
-                "reference": "65fe7b49868378319b82da3035fb30801b931c47",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/157bbec4fd773bae53c5483c50951a5530a2cc16",
+                "reference": "157bbec4fd773bae53c5483c50951a5530a2cc16",
                 "shasum": ""
             },
             "require": {
@@ -2515,7 +2517,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
             "funding": [
                 {
@@ -2531,7 +2533,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-28T20:42:29+00:00"
+            "time": "2021-01-28T16:54:48+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -2850,16 +2852,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
@@ -2871,7 +2873,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2922,20 +2924,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024"
+                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/c536646fdb4f29104dd26effc2fdcb9a5b085024",
-                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/06fb361659649bcfd6a208a0f1fcaf4e827ad342",
+                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342",
                 "shasum": ""
             },
             "require": {
@@ -2947,7 +2949,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2999,20 +3001,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117"
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/3b75acd829741c768bc8b1f84eb33265e7cc5117",
-                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
+                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
                 "shasum": ""
             },
             "require": {
@@ -3026,7 +3028,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3083,20 +3085,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "727d1096295d807c309fb01a851577302394c897"
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
-                "reference": "727d1096295d807c309fb01a851577302394c897",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
                 "shasum": ""
             },
             "require": {
@@ -3108,7 +3110,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3164,20 +3166,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
                 "shasum": ""
             },
             "require": {
@@ -3189,7 +3191,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3241,7 +3243,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -3375,16 +3377,16 @@
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930"
+                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cede45fcdfabdd6043b3592e83678e42ec69e930",
-                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
+                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
                 "shasum": ""
             },
             "require": {
@@ -3393,7 +3395,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3444,20 +3446,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
+                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
                 "shasum": ""
             },
             "require": {
@@ -3466,7 +3468,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3524,7 +3526,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "symfony/process",
@@ -4066,16 +4068,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.44.1",
+            "version": "v1.44.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9"
+                "reference": "138c493c5b8ee7cff3821f80b8896d371366b5fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
-                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/138c493c5b8ee7cff3821f80b8896d371366b5fe",
+                "reference": "138c493c5b8ee7cff3821f80b8896d371366b5fe",
                 "shasum": ""
             },
             "require": {
@@ -4136,7 +4138,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-27T19:22:48+00:00"
+            "time": "2021-01-05T10:10:05+00:00"
         },
         {
             "name": "typo3/phar-stream-wrapper",
@@ -4255,6 +4257,67 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "drupal/migrate_plus",
+            "version": "5.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/migrate_plus.git",
+                "reference": "8.x-5.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/migrate_plus-8.x-5.1.zip",
+                "reference": "8.x-5.1",
+                "shasum": "1257427ab0c64459c3c1e42bb2a98d3114b77163"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "drupal/migrate_example_advanced_setup": "*",
+                "drupal/migrate_example_setup": "*"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "sainsburys/guzzle-oauth2-plugin": "3.0 required for the OAuth2 authentication plugin"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-5.1",
+                    "datestamp": "1588261060",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Mike Ryan",
+                    "homepage": "https://www.drupal.org/u/mikeryan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Lucas Hedding",
+                    "homepage": "https://www.drupal.org/u/heddn",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Enhancements to core migration support.",
+            "homepage": "https://www.drupal.org/project/migrate_plus",
+            "support": {
+                "source": "https://git.drupalcode.org/project/migrate_plus",
+                "issues": "https://www.drupal.org/project/issues/migrate_plus",
+                "slack": "#migrate"
+            }
         },
         {
             "name": "myclabs/deep-copy",
@@ -4560,16 +4623,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.1",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -4581,7 +4644,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -4619,7 +4682,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-09-29T09:10:42+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5644,30 +5707,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -5689,7 +5757,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],

--- a/src/Plugin/migrate/process/ParseEntityLookup.php
+++ b/src/Plugin/migrate/process/ParseEntityLookup.php
@@ -1,0 +1,216 @@
+<?php
+
+
+namespace Drupal\idc_migration\Plugin\migrate\process;
+
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Configures and invokes the `entity_lookup` plugin using arguments that are parsed from a source field.  This plugin
+ * may be used wherever an `entity_lookup` plugin may be used, provided that the values being processed by this plugin
+ * adhere to the format documented below.<br><br>
+ *
+ * This plugin will parse a string with the following form, assuming the `delimiter` configuration parameter is equal to
+ * the colon character:<br><br>
+ *   `<entity_type>:<bundle_key>:<bundle_name>:<value_key>:<value>`<br><br>
+ * For example, `taxonomy_term:vid:subject:name:History`.  The form of the string provides an unambiguous reference that
+ * can be used to configure and invoke the `entity_lookup` plugin.<br><br>
+ *
+ * When a default value is provided by the `defaults` configuration key, it may be elided from the string being
+ * processed.  For example, given the defaults:
+ *
+ * ```
+ *     defaults:
+ *      entity_type: taxonomy_term
+ *      bundle_key: vid
+ *      value_key: name
+ * ```
+ *
+ * The above example could be written as: `::subject::History`.<br><br>
+ *
+ * If a value is elided from the string and there is no default provided by the plugin configuration, then the value
+ * will not be passed to the `entity_lookup` plugin.  This may be the case when an entity does not have a bundle (e.g.
+ * the `User` entity type does not have bundles).<br><br>
+ *
+ * By default the delimiter used by this plugin is the colon character.  A different delimiter may be configured using
+ * the `delimiter` configuration key documented below.  Delimiters may be longer than a single character, but they
+ * _must_ be latin-1 characters.  If a delimiter appears as a value in the string being processed (i.e. it is not meant
+ * to be parsed as a delimiter), then it must be "percent-encoded".  For example, if the value being processed by this
+ * plugin is: `node:nid:islandora_object:title:The Story of My Life: An Autobiography`, the colon between "Life" and
+ * "An Autobiography" must be percent encoded as: `node:nid:islandora_object:title:The Story of My Life%3A An Autobiography`.
+ * If encoding the colon is not desirable, a different delimiter may be configured.<br><br>
+ *
+ * Available configuration keys:
+ *
+ * * `defaults`: an associative array of default values used to parameterize the `entity_lookup` plugin when elided from the source string.  Possible values include any keys supported by the `entity_lookup` plugin.
+ * * `delimiter`: the character string used to delimit the fields of the source string; it must be from the basic latin character set.
+ *
+ * Example:
+ * ```
+ * process:
+ *   plugin: parse_entity_lookup
+ *     source: subject
+ *     delimiter: ':'
+ *     defaults:
+ *      entity_type: taxonomy_term
+ *      bundle_key: vid
+ *      bundle_name: subject
+ *      value_key: name
+ * ```
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ * @MigrateProcessPlugin(
+ *   id = "parse_entity_lookup",
+ *   handle_multiples = TRUE
+ * )
+ */
+class ParseEntityLookup extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+    /**
+     * The default delimiter used to separate the fields in the $value being processed by the transform(...) method.<br><br>
+     *
+     * Note: the delimiter must be from the basic latin character set.
+     */
+    private const default_delimiter = ':';
+
+    /**
+     * Maps RFC 3986 reserved characters to their percent-encoded equivalent
+     */
+    private const reserved_char_map = [
+        '-' => '%2d',
+        '_' => '%5f',
+        '.' => '%2e',
+        '~' => '%7e',
+    ];
+
+    /**
+     * DI key for the MigratePluginManager instance
+     */
+    static $migrate_plugin_manager = 'plugin.manager.migrate.process';
+
+    /**
+     * The migration.
+     *
+     * @var \Drupal\migrate\Plugin\MigrationInterface
+     */
+    protected $migration;
+
+    /**
+     * The migration plugin manager, used to retrieve the 'entity_lookup' plugin definition.
+     *
+     * @var \Drupal\migrate\Plugin\MigratePluginManager
+     */
+    protected $migration_plugin_manager;
+
+    public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
+        $instance = new static(
+            $configuration,
+            $plugin_id,
+            $plugin_definition
+        );
+
+        $instance->migration = $migration;
+
+        $instance->migration_plugin_manager = $container->get(self::$migrate_plugin_manager);
+
+        return $instance;
+    }
+
+    public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+        $delimiter = $this->configuration['delimiter'] ?: self::default_delimiter;
+
+        // split the fields in the value into an array using the defined delimiter
+        $split_values = explode($delimiter, $value);
+
+        // unescape the fields in case they contain the separator, and trim any whitespace
+        foreach ($split_values as &$unescaped_value) {
+            $unescaped_value = trim($this->decode($delimiter, $unescaped_value));
+        }
+
+        // transform the values from the spreadsheet to an `entity_lookup` config and supply the default values.
+        $entity_lookup_configuration = $this->applyDefaults(
+            $this->toEntityLookupConfig($split_values), $this->configuration['defaults']);
+
+        // create an instance of the entity_lookup plugin using the configuration supplied by the migration
+        $entity_lookup_plugindef = $this->migration_plugin_manager->getDefinitions()['entity_lookup'];
+        $entity_lookup_plugin = $this->migration_plugin_manager->createInstance($entity_lookup_plugindef['id'],
+            $entity_lookup_configuration, $this->migration);
+
+        // invoke the entity_lookup plugin with the last portion of the original value, and return
+        return $entity_lookup_plugin->transform($split_values[3], $migrate_executable, $row, $destination_property);
+    }
+
+    /**
+     * Transforms the source values obtained from the migration into an array representing the entity_lookup configuration.<br><br>
+     *
+     * Note that caller is responsible for applying the defaults provided by this (`parse_entity_plugin`) plugin.
+     *
+     * @param array $split_values source values from the migration as an array keyed by integers
+     * @return array an array suitable for use as an `entity_lookup` configuration (i.e. a map with string keys)
+     */
+    function toEntityLookupConfig($split_values): array {
+        // Values from the spreadsheet will be indexed with integers.  Map them to configuration keys.
+
+        $entity_lookup_configuration_from_values = [
+            'entity_type' => $split_values[0],
+            'bundle' => $split_values[1],
+            'value_key' => $split_values[2],
+        ];
+
+        // If a key is the zero-length string or null, redact it from the returned array.  Some entity types
+        // (e.g. Users) do not use all the configuration keys (e.g. bundles), and to have them present in the
+        // configuration is a fatal error.
+
+        foreach ($entity_lookup_configuration_from_values as $k => $v) {
+            if ($v === NULL || '' === trim($v)) {
+                unset($entity_lookup_configuration_from_values[$k]);
+            }
+        }
+
+        return $entity_lookup_configuration_from_values;
+    }
+
+    /**
+     * Decodes the provided string.  If $delimiter is present in its percent-encoded form in $string, this method will
+     * decode the percent-encoded form into $delimiter, and return the decoded string.
+     *
+     * @param string $delimiter the delimiter used to separate the fields in the $value being processed by the transform(...) method.  Note the delimiter must be from the basic latin character set.
+     * @param string $string a string that may contain the percent-encoded form of $delimiter
+     * @return string the decoded string
+     */
+    function decode(string $delimiter, string $string): string {
+        $encoded_delimiter = '';
+        foreach (str_split($delimiter) as $char) {
+            if (array_key_exists($char, self::reserved_char_map)) {
+                $encoded_delimiter .= self::reserved_char_map[$char];
+                continue;
+            }
+            $encoded_delimiter .= rawurlencode($char);
+        }
+
+        $decoded_string = str_ireplace($encoded_delimiter, $delimiter, $string);
+
+        return $decoded_string;
+    }
+
+    /**
+     * Merges two arrays keyed by strings.  The first array is parsed from the spreadsheet, the second array is provided
+     * by this plugin's configuration.  Values from the spreadsheet will override the plugin configuration; if a value
+     * is elided from the spreadsheet, it will be provided by the plugin configuration.
+     *
+     * @param array $entity_lookup_config an array containing the 'entity_lookup' configuration parsed from the source values in the spreadsheet
+     * @param array $defaults an array of default values merged with $entity_lookup_config
+     * @return array the merged array
+     */
+    function applyDefaults($entity_lookup_config, $defaults): array {
+        return array_merge($defaults, $entity_lookup_config);
+    }
+
+
+}

--- a/tests/Plugin/migrate/process/ParseEntityLookupTest.php
+++ b/tests/Plugin/migrate/process/ParseEntityLookupTest.php
@@ -1,0 +1,369 @@
+<?php
+
+namespace Drupal\idc_migration\Plugin\migrate\process;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigratePluginManager;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate_plus\Plugin\migrate\process\EntityLookup;
+use Drupal\Tests\migrate\Unit\process\MigrateProcessTestCase;
+
+class ParseEntityLookupTest extends MigrateProcessTestCase {
+
+    /**
+     * 'entity_lookup' plugin definition
+     */
+    private static $entity_lookup_plugindef = [
+        'handle_multiples' => true,
+        'id' => 'entity_lookup',
+        'class' => 'Drupal\migrate_plus\Plugin\migrate\process\EntityLookup',
+        'provider' => 'migrate_plus'
+    ];
+
+    /**
+     * 'parse_entity_lookup' plugin definition
+     */
+    private static $parse_entity_lookup_plugindef = [
+        'handle_multiples' => true,
+        'id' => 'parse_entity_lookup',
+        'class' => 'Drupal\idc_migration\Plugin\migrate\process',
+        'provider' => 'idc_migration'
+    ];
+
+    /**
+     * 'parse_entity_lookup' plugin configuration
+     */
+    private static $parse_entity_lookup_config = [
+        'delimiter' => ':',
+        'defaults' => [
+            'entity_type' => 'taxonomy_term',
+            'bundle_key' => 'vid',
+            'bundle' => 'subject',
+            'value_key' => 'name',
+        ],
+    ];
+
+    /**
+     * Mock instance of MigratePluginManager
+     */
+    private $mockPluginMgr;
+
+    /**
+     * Mock instance of EntityLookup plugin
+     */
+    private $mockEntityLookupPlugin;
+
+    /**
+     * Mock instance of MigrationExecutableInterface
+     */
+    private $mockMigrationExe;
+
+    /**
+     * Mock instance of MigrationInterface
+     */
+    private $mockMigration;
+
+    /**
+     * Mock \Drupal\migrate\Row
+     */
+    private $mockRow;
+
+    /**
+     * Instance of ParseEntityLookup plugin under test
+     */
+    private $underTest;
+
+    protected function setUp() {
+        parent::setUp();
+
+        $this->mockPluginMgr = $this->getMockBuilder(MigratePluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockEntityLookupPlugin = $this->getMockBuilder(EntityLookup::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockMigrationExe = $this->getMockBuilder(MigrateExecutableInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockMigration = $this->getMockBuilder(MigrationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->mockRow = $this->getMockBuilder(Row::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $container = new ContainerBuilder();
+        $container->set(ParseEntityLookup::$migrate_plugin_manager, $this->mockPluginMgr);
+        \Drupal::setContainer($container);
+
+        $this->underTest = ParseEntityLookup::create(
+            $container,
+            self::$parse_entity_lookup_config,
+            self::$parse_entity_lookup_plugindef['id'],
+            self::$parse_entity_lookup_plugindef,
+            $this->mockMigration);
+    }
+
+    /**
+     * Given expected input, a valid entity_lookup configuration should be returned
+     */
+    public function testToEntityLookupConfigOk() {
+        $split_values = [
+            0 => 'taxonomy_term',
+            1 => 'subject',
+            2 => 'name',
+            3 => 'History',
+        ];
+
+        $config = $this->underTest->toEntityLookupConfig($split_values);
+
+        self::assertNotEmpty($config);
+
+        // The 4th element (e.g. 'History') is not part of the configuration
+        self::assertEquals(3, sizeof($config));
+        self::assertEquals('taxonomy_term', $config['entity_type']);
+        self::assertEquals('subject', $config['bundle']);
+        self::assertEquals('name', $config['value_key']);
+    }
+
+    /**
+     * Null values should be elided from the returned entity_lookup configuration
+     */
+    public function testToEntityLookupNullValue() {
+        $split_values = [
+            0 => 'taxonomy_term',
+            1 => 'subject',
+            2 => NULL,
+            3 => 'History',
+        ];
+
+        $config = $this->underTest->toEntityLookupConfig($split_values);
+
+        self::assertNotEmpty($config);
+
+        self::assertEquals(2, sizeof($config));
+        self::assertEquals('taxonomy_term', $config['entity_type']);
+        self::assertEquals('subject', $config['bundle']);
+    }
+
+    /**
+     * Zero-length strings should be elided from the returned entity_lookup configuration
+     */
+    public function testToEntityLookupZeroLengthStringValue() {
+        $split_values = [
+            0 => 'taxonomy_term',
+            1 => '',
+            2 => 'name',
+            3 => 'History',
+        ];
+
+        $config = $this->underTest->toEntityLookupConfig($split_values);
+
+        self::assertNotEmpty($config);
+
+        self::assertEquals(2, sizeof($config));
+        self::assertEquals('taxonomy_term', $config['entity_type']);
+        self::assertEquals('name', $config['value_key']);
+    }
+
+    /**
+     * Empty strings should be elided from the returned entity_lookup configuration
+     */
+    public function testToEntityLookupEmptyStringValue() {
+        $split_values = [
+            0 => 'taxonomy_term',
+            1 => '  ',
+            2 => 'name',
+            3 => 'History',
+        ];
+
+        $config = $this->underTest->toEntityLookupConfig($split_values);
+
+        self::assertNotEmpty($config);
+
+        self::assertEquals(2, sizeof($config));
+        self::assertEquals('taxonomy_term', $config['entity_type']);
+        self::assertEquals('name', $config['value_key']);
+    }
+
+    /**
+     * Simple decoding test using a lower-case encoded delimiter
+     */
+    public function testDecodeLowercaseOk() {
+        self::assertEquals("foo:bar", $this->underTest->decode(":", "foo%3abar"));
+    }
+
+    /**
+     * Simple decoding test using an upper-case encoded delimiter
+     */
+    public function testDecodeUppercaseOk() {
+        self::assertEquals("foo:bar", $this->underTest->decode(":", "foo%3Abar"));
+    }
+
+    /**
+     * Simple decoding test where there is no delimiter present to decode
+     */
+    public function testDecodeNoDelimiterOk() {
+        self::assertEquals("foobar", $this->underTest->decode(":", "foobar"));
+    }
+
+    /**
+     * Simple decoding test insuring RFC 3986 reserved characters can be decoded
+     */
+    public function testDecodeRfc3986ReservedCharacters() {
+        self::assertEquals("foo-bar", $this->underTest->decode("-", "foo%2dbar"));
+        self::assertEquals("foo_bar", $this->underTest->decode("_", "foo%5fbar"));
+        self::assertEquals("foo.bar", $this->underTest->decode(".", "foo%2ebar"));
+        self::assertEquals("foo~bar", $this->underTest->decode("~", "foo%7ebar"));
+    }
+
+    /**
+     * Insure a '%' can be used as a delimiter
+     */
+    public function testDecodePercentDelimiter() {
+        self::assertEquals("foo%bar", $this->underTest->decode("%", "foo%25bar"));
+    }
+
+    /**
+     * Other potential delimiters
+     */
+    public function testDecodeOtherPotentialDelimiters() {
+        self::assertEquals("foo;bar", $this->underTest->decode(";", "foo%3bbar"));
+        self::assertEquals("foo bar", $this->underTest->decode(" ", "foo%20bar"));
+        self::assertEquals("foo+bar", $this->underTest->decode("+", "foo%2bbar"));
+        self::assertEquals("foo@bar", $this->underTest->decode("@", "foo%40bar"));
+        self::assertEquals("foo#bar", $this->underTest->decode("#", "foo%23bar"));
+        self::assertEquals("foo|bar", $this->underTest->decode("|", "foo%7cbar"));
+    }
+
+    /**
+     * Insure multi-character delimiter strings are supported
+     */
+    public function testDecodeMulticharacterDelimiter() {
+        self::assertEquals("foo  bar", $this->underTest->decode("  ", "foo%20%20bar"));
+        self::assertEquals("foo ;bar", $this->underTest->decode(" ;", "foo%20%3bbar"));
+    }
+
+    /**
+     * Insure the defaults supplied from the plugin configuration will be present in the merged array if elided from
+     * source config.
+     */
+    public function testApplyDefaultsSuppliesElidedValues() {
+        $result = $this->underTest->applyDefaults(
+            [
+                'source-value' => 'foo'
+            ],
+            [
+                'default-value' => 'bar'
+            ]);
+
+        self::assertEquals(2, sizeof($result));
+        self::assertTrue(array_key_exists('source-value', $result));
+        self::assertTrue(array_key_exists('default-value', $result));
+        self::assertEquals('foo', $result['source-value']);
+        self::assertEquals('bar', $result['default-value']);
+    }
+
+    /**
+     * Insure the values from the source config override values provided by defaults when the same key is shared.
+     */
+    public function testApplyDefaultsOverriddenBySourceValues() {
+        $result = $this->underTest->applyDefaults(
+            [
+                'a-value' => 'foo'
+            ],
+            [
+                'a-value' => 'bar'
+            ]);
+
+        self::assertEquals(1, sizeof($result));
+        self::assertTrue(array_key_exists('a-value', $result));
+        self::assertEquals('foo', $result['a-value']);
+    }
+
+    /**
+     * Big picture: the transform() method of the parse_entity_lookup plugin (the instance under test) creates an
+     * instance of the entity_lookup plugin and delegates to its transform method.  The _configuration_ supplied to the
+     * entity_lookup plugin is parsed from the _source_ values obtains from the spreadsheet.<br><br>
+     *
+     * Essentially, values from the spreadsheet parameterize the configuration for the entity_lookup plugin.<br><br>
+     *
+     * In this test, we simply verify that each mock receives the expected arguments when it is invoked.
+     */
+    public function testTransformOk() {
+        // The source value from the spreadsheet in the form:
+        //   <entity type>:<bundle>:<value_key>:<value>
+        // Elided values from the source_value are provided by the 'defaults' configuration key of the
+        // parse_entity_lookup plugin.
+        $source_value = ":subject:name:History";
+
+        // Mocks MigratePluginManager::getDefinitions.
+        // Used to look up the entity_lookup plugin definition.
+        $getDefinitionsInvoked = false;
+        $this->mockPluginMgr->expects($this->any())
+            ->method('getDefinitions')
+            ->willReturnCallback(function () use (&$getDefinitionsInvoked) {
+                // TODO consider using Prophecy for verifying expectations
+                $getDefinitionsInvoked = true;
+                return [
+                    'entity_lookup' => self::$entity_lookup_plugindef
+                ];
+            });
+
+        // Entity Lookup plugin instance that will be returned by MigratePluginManager::createInstance(...)
+        $entity_lookup_plugin = $this->mockEntityLookupPlugin;
+
+        // Mocks MigratePluginManager::createInstance.
+        // Used to create the instance of the entity_lookup plugin.
+        $createInstanceInvoked = false;
+        $this->mockPluginMgr->expects($this->any())
+            ->method('createInstance')
+            ->willReturnCallback(function ($id, $config, $migration) use ($entity_lookup_plugin, &$createInstanceInvoked) {
+                self::assertEquals('entity_lookup', $id);
+                self::assertNotNull($migration);
+
+                // This is the configuration for the entity_lookup plugin, created by combining values parsed from the
+                // $source_value and parse_entity_lookup configuration defaults.
+                self::assertNotempty($config);
+                self::assertEquals([
+                    'entity_type' => 'taxonomy_term',
+                    'bundle_key' => 'vid',
+                    'bundle' => 'subject',
+                    'value_key' => 'name'
+                ], $config);
+
+                $createInstanceInvoked = true;
+                return $entity_lookup_plugin;
+            });
+
+        // Mock MigrateProcessInterface::transform of the entity_lookup plugin.
+        // Simply assert that we receive the expected values from the parse_entity_lookup plugin.
+        // Returns a random value.
+        $transformInvoked = false;
+        $this->mockEntityLookupPlugin->expects($this->once())
+            ->method('transform')
+            ->willReturnCallback(function ($value, $migrate_executable, $row, $destination_property) use (&$transformInvoked) {
+                self::assertEquals("History", $value);
+                self::assertNotNull($migrate_executable);
+                $transformInvoked = true;
+                return "1234";
+            });
+
+        $result = $this->underTest->transform($source_value, $this->mockMigrationExe, new Row(), "foo");
+
+        self::assertEquals("1234", $result);
+
+        // verify mocks (TODO: consider using Prophecy for mock verification)
+        self::assertTrue($getDefinitionsInvoked);
+        self::assertTrue($createInstanceInvoked);
+        self::assertTrue($transformInvoked);
+    }
+
+
+}


### PR DESCRIPTION
Adds the `parse_entity_lookup` plugin which is used to support the parameterization of `entity_lookup` plugins from spreadsheet values.

Addresses https://github.com/jhu-idc/iDC-general/issues/317